### PR TITLE
Do not index nil values

### DIFF
--- a/lib/ohm/sorted.rb
+++ b/lib/ohm/sorted.rb
@@ -219,7 +219,10 @@ module Ohm
 
     def add_sorted_indices
       update_sorted_indices do |key, attribute, options|
-        score = send(attribute).to_f
+        attr = send(attribute)
+        next if attr.nil?
+
+        score = attr.to_f
         db.zadd(key, score, id)
       end
     end

--- a/test/sorted_test.rb
+++ b/test/sorted_test.rb
@@ -105,10 +105,10 @@ class SortedTest < Test::Unit::TestCase
     assert_equal [], sorted_set.to_a
   end
 
-  def test_indexes_nil
+  def test_does_not_index_nil
     post = Post.create(status: "draft")
     sorted_set = Post.sorted_find(:order, status: "draft")
-    assert_equal [post], sorted_set.to_a
+    assert_equal [], sorted_set.to_a
   end
 
   def test_sorted_find_invalid


### PR DESCRIPTION
nil values shouldn't be indexed by default. You should call explicitly `value.to_f` if you want that behaviour.
